### PR TITLE
Refine Modal Popup by combining two seprate pickers into one

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { StyleSheet, View, SafeAreaView, StatusBar } from 'react-native';
+import { AppearanceProvider } from 'react-native-appearance';
 import store from './store';
 import Colors from './constants/Colors';
 import useCachedResources from './hooks/useCachedResources';
@@ -29,26 +30,28 @@ export default function App(params) {
       <StatusBar barStyle="light-content" />
 
       <View style={styles.container}>
-        <Provider store={store}>
-          <NavigationContainer>
-            <Stack.Navigator
-              screenOptions={{
-                headerStyle: { backgroundColor: Colors.tintColor },
-                headerTintColor: Colors.defaultWhite,
-              }}>
-              <Stack.Screen name="Root" component={BottomTabNavigator} />
-              <Stack.Screen name="Camera" component={CameraScreen} />
-              <Stack.Screen name="IndividualPlant" component={IndividualPlantScreen} />
-              <Stack.Screen
-                name="IndividualArticle"
-                component={IndividualArticle}
-                options={({ route }) => ({ title: route.params.article.label })}
-              />
-              <Stack.Screen name="MyPlant" component={MyPlantScreen} />
-              <Stack.Screen name="Auth" component={AuthScreen} />
-            </Stack.Navigator>
-          </NavigationContainer>
-        </Provider>
+        <AppearanceProvider>
+          <Provider store={store}>
+            <NavigationContainer>
+              <Stack.Navigator
+                screenOptions={{
+                  headerStyle: { backgroundColor: Colors.tintColor },
+                  headerTintColor: Colors.defaultWhite,
+                }}>
+                <Stack.Screen name="Root" component={BottomTabNavigator} />
+                <Stack.Screen name="Camera" component={CameraScreen} />
+                <Stack.Screen name="IndividualPlant" component={IndividualPlantScreen} />
+                <Stack.Screen
+                  name="IndividualArticle"
+                  component={IndividualArticle}
+                  options={({ route }) => ({ title: route.params.article.label })}
+                />
+                <Stack.Screen name="MyPlant" component={MyPlantScreen} />
+                <Stack.Screen name="Auth" component={AuthScreen} />
+              </Stack.Navigator>
+            </NavigationContainer>
+          </Provider>
+        </AppearanceProvider>
         <StatusBar style="auto" />
       </View>
     </>

--- a/app.json
+++ b/app.json
@@ -19,7 +19,8 @@
       "useNextNotificationsApi": true
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "userInterfaceStyle": "automatic"
     },
     "web": {
       "favicon": "./assets/images/favicon.png"

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
-import Colors from '../constants/Colors';
+import moment from 'moment';
 import SetReminderNotification from './SetReminderNotification';
 
 const DateTimePicker = () => {
   const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
+  const [dateInput, setDateInput] = useState('');
 
   const showDatePicker = () => {
     setDatePickerVisibility(true);
@@ -16,17 +17,19 @@ const DateTimePicker = () => {
   };
 
   const handleConfirm = (date) => {
-    console.warn('A date has been picked: ', date);
+    hideDatePicker();
+
+    // console.warn('A date has been picked: ', date);
     const dateParsedToNum = date.toString();
     SetReminderNotification(dateParsedToNum);
 
-    hideDatePicker();
+    setDateInput(moment(date).format('MMMM Do, h:mm a'));
   };
 
   return (
     <TouchableOpacity onPress={showDatePicker}>
       <View style={styles.datePickerBtnContainer}>
-        <Text style={styles.datePickerBtn}>Set reminder</Text>
+        <Text style={styles.datePickerBtn}>{dateInput || '__ /__ /__ : __ :'}</Text>
       </View>
       <DateTimePickerModal
         isVisible={isDatePickerVisible}
@@ -42,17 +45,12 @@ export default DateTimePicker;
 
 const styles = StyleSheet.create({
   datePickerBtnContainer: {
-    width: 240,
-    borderRadius: 50,
-    backgroundColor: Colors.tintColor,
-    padding: 10,
-    marginBottom: 30,
+    width: 220,
+    marginLeft: 20,
   },
 
   datePickerBtn: {
-    textAlign: 'center',
-    fontSize: 16,
-    color: Colors.defaultWhite,
-    fontWeight: '600',
+    fontSize: 14,
+    color: 'gray',
   },
 });

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -2,11 +2,15 @@ import React, { useState } from 'react';
 import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import moment from 'moment';
+import { Appearance, useColorScheme } from 'react-native-appearance';
 import SetReminderNotification from './SetReminderNotification';
+
+console.log(Appearance.getColorScheme());
 
 const DateTimePicker = () => {
   const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
   const [dateInput, setDateInput] = useState('');
+  const colorScheme = useColorScheme();
 
   const showDatePicker = () => {
     setDatePickerVisibility(true);
@@ -36,6 +40,7 @@ const DateTimePicker = () => {
         mode="datetime"
         onConfirm={handleConfirm}
         onCancel={hideDatePicker}
+        style={{ backgroundColor: `${colorScheme === 'light' ? 'white' : 'black'}` }}
       />
     </TouchableOpacity>
   );

--- a/components/ModalConfigPopup.js
+++ b/components/ModalConfigPopup.js
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
   careOptions: {
     borderWidth: 1,
     borderColor: 'lightgray',
-    borderRadius: 20,
+    borderRadius: 11,
     paddingHorizontal: 20,
     paddingVertical: 4,
     fontSize: 12,

--- a/components/ModalConfigPopup.js
+++ b/components/ModalConfigPopup.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity, Switch, TextInput } from 'react-native';
-import { MaterialCommunityIcons, FontAwesome5, Fontisto, AntDesign } from '@expo/vector-icons';
+import { MaterialCommunityIcons, Fontisto, AntDesign } from '@expo/vector-icons';
 import Modal from 'react-native-modal';
 import Colors from '../constants/Colors';
-import DatePicker from './DatePicker';
-import TimePicker from './TimePicker';
-import SetReminderNotification from './SetReminderNotification';
+import DateTimePicker from './DateTimePicker';
 
 const ModalConfigPopup = () => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -13,15 +11,6 @@ const ModalConfigPopup = () => {
   const toggleSwitch = () => setSwitchEnabled((previousState) => !previousState);
 
   const [reminderItem, setReminderItem] = useState('');
-  const [reminderDateInput, setReminderDateInput] = useState();
-  const [reminderTimeInput, setReminderTimeInput] = useState();
-
-  const dateRetriever = (data) => setReminderDateInput(data);
-  const timeRetriever = (data) => setReminderTimeInput(data);
-
-  const sumMilliSec = reminderDateInput + reminderTimeInput;
-
-  SetReminderNotification(sumMilliSec || '');
 
   return (
     <View>
@@ -45,12 +34,12 @@ const ModalConfigPopup = () => {
         backdropTransitionOutTiming={40}>
         <View style={styles.modalContent}>
           <View style={styles.headerOptions}>
-            <TouchableOpacity style={styles.cancelDoneText} onPress={() => setModalOpen(false)}>
+            <TouchableOpacity onPress={() => setModalOpen(false)}>
               <Text>Cancel</Text>
             </TouchableOpacity>
             <Text>New Reminder</Text>
-            <TouchableOpacity style={styles.cancelDoneText} onPress={() => setModalOpen(false)}>
-              <Text>Done</Text>
+            <TouchableOpacity onPress={() => setModalOpen(false)}>
+              <Text style={styles.doneTextColor}>Done</Text>
             </TouchableOpacity>
           </View>
           <View style={styles.modalRows}>
@@ -88,19 +77,7 @@ const ModalConfigPopup = () => {
           </View>
           <View style={styles.modalRows}>
             <AntDesign name="calendar" size={18} color={Colors.tintColor} />
-            <DatePicker
-              dateInput={(data) => {
-                dateRetriever(data);
-              }}
-            />
-          </View>
-          <View style={styles.modalRows}>
-            <FontAwesome5 name="clock" size={18} color={Colors.tintColor} />
-            <TimePicker
-              timeInput={(data) => {
-                timeRetriever(data);
-              }}
-            />
+            <DateTimePicker />
           </View>
           <View style={[styles.repeater, styles.modalRows]}>
             <View style={styles.repeatInputSnippet}>
@@ -120,7 +97,7 @@ export default ModalConfigPopup;
 const styles = StyleSheet.create({
   modalContent: {
     backgroundColor: 'white',
-    height: 320,
+    height: 280,
     borderRadius: 10,
     padding: 20,
   },
@@ -178,7 +155,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
 
-  cancelDoneText: {
-    color: 'gray',
+  doneTextColor: {
+    color: Colors.tintColor,
   },
 });

--- a/components/SetReminderNotification.js
+++ b/components/SetReminderNotification.js
@@ -1,8 +1,8 @@
 import * as Notifications from 'expo-notifications';
 
 // Receives date info from DateTimePicker & sends notification
-export default function SetReminderNotification(notificationInputInMillisec) {
-  // console.warn('A data sent from DateTimePicker!', notificationInputInMillisec);
+export default function SetReminderNotification(dateInputInString) {
+  // console.warn('A data sent from DateTimePicker!', dateInputInString);
 
   allowsNotificationsAsync()
   requestPermissionsAsync()
@@ -15,7 +15,8 @@ export default function SetReminderNotification(notificationInputInMillisec) {
     }),
   });
 
-  const dateInSec = (notificationInputInMillisec - Date.now()) / 1000;
+  const timeLeftInSec = (new Date(dateInputInString).getTime() - Date.now()) / 1000;
+  // console.warn(timeLeftInSec)
 
   Notifications.scheduleNotificationAsync({
     content: {
@@ -23,7 +24,7 @@ export default function SetReminderNotification(notificationInputInMillisec) {
       body: "I'm so thirsty🌵...",
     },
     trigger: {
-      seconds: dateInSec,
+      seconds: timeLeftInSec,
       // repeats: true,
     },
   });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "16.11.0",
     "react-dom": "16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",
+    "react-native-appearance": "^0.3.4",
     "react-native-elements": "^2.0.4",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-image-zoom-viewer": "^3.0.1",

--- a/screens/MyPlantScreen.js
+++ b/screens/MyPlantScreen.js
@@ -8,7 +8,6 @@ import BottomSheet from 'reanimated-bottom-sheet';
 import Animated from 'react-native-reanimated';
 import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import Colors from '../constants/Colors';
-import DateTimePicker from '../components/DateTimePicker';
 import PflanzyOpacity from '../components/PflanzyOpacity';
 import ModalConfigPopup from '../components/ModalConfigPopup';
 
@@ -48,7 +47,6 @@ const MyGardenPlant = (props) => {
       <View style={styles.settingsHeader}>
         <View style={styles.contentHandle} />
         <ModalConfigPopup />
-        <DateTimePicker />
       </View>
     </View>
   );


### PR DESCRIPTION
I've changed the Modal options a bit for technical reasons so you have only one Date/Time Picker, instead of two separate pickers. Let me know if this works on both Android and iPhone. 

* To test, you can simply add one minute to the current time 